### PR TITLE
Feature flag to conditionally compile with parquet support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ include = [
     "Cargo.toml",
 ]
 
+[features]
+default = ["parquet_support"]
+parquet_support = ["parquet"]
+
 [lib]
 name = "datafusion"
 path = "src/lib.rs"
@@ -33,7 +37,7 @@ csv = "1.0.0"
 arrow = "0.10.0"
 
 lazy_static = "1.0"
-parquet = "0.3.0"
+parquet = { version = "0.3.0", optional = true }
 #parquet = { path = "../parquet-rs" }
 json = "0.11.13"
 clap = "2.31.2"

--- a/src/datasources/mod.rs
+++ b/src/datasources/mod.rs
@@ -18,5 +18,6 @@ pub mod common;
 pub mod csv;
 pub mod empty;
 pub mod ndjson;
+#[cfg(feature = "parquet_support")]
 pub mod parquet;
 //pub mod quiver;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ extern crate csv;
 extern crate datafusion_rustyline;
 extern crate fnv;
 extern crate json;
+#[cfg(feature = "parquet_support")]
 extern crate parquet;
 
 #[macro_use]


### PR DESCRIPTION
Parquet support breaks compilation for the dylib or cdylib crate types, which are necessary to create bindings to use Datafusion from another language. (Issue #173 ) This doesn't exactly fix it, but it allows me to disable Parquet support so cdylib compilation can succeed.

I am a novice at Rust, and I'm happy to receive feedback if I've gone about this the wrong way.